### PR TITLE
Add dependencies installation step in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-nl -ba .github/workflows/ci.yml | sed -n '1,80p'  # just to confirm before overwriting
+
 
 # Overwrite with a conflict-free version:
 cat > .github/workflows/ci.yml <<'YAML'


### PR DESCRIPTION
Added installation of cmake, ninja-build, and libboost dependencies.

## Summary by Sourcery

CI:
- Install cmake, ninja-build, and boost libraries before running CI jobs