### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -1,4 +1,6 @@
 name: Container Scan
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/jblanc86-maker/quant-lob-engine/security/code-scanning/11](https://github.com/jblanc86-maker/quant-lob-engine/security/code-scanning/11)

To address the problem, add an explicit `permissions` block to the workflow to restrict the default `GITHUB_TOKEN` permissions to the minimum necessary. In this workflow, none of the steps need write repository access: they check out code, build images, run scans, and upload artifacts; none push changes or modify GitHub data. The minimal required permission set is likely `contents: read`. Adding this at the root level (just after the `name` line) makes the restriction global to all jobs in this workflow.  

**Changes to make:**  
- Insert the following block at the top level of `.github/workflows/container-scan.yml`, after the `name` field and before the `on` field:
  ```yaml
  permissions:
    contents: read
  ```
No additional imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add an explicit permissions block to the container-scan GitHub Actions workflow, limiting GITHUB_TOKEN to read-only contents access.